### PR TITLE
Add actions for releasing forked `opampsupervisor` image

### DIFF
--- a/.github/workflows/opampsupervisor-e2e-tests.yml
+++ b/.github/workflows/opampsupervisor-e2e-tests.yml
@@ -1,0 +1,117 @@
+name: opampsupervisor-e2e-tests
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+    paths-ignore:
+      - "**/README.md"
+  pull_request:
+    paths-ignore:
+      - "**/README.md"
+    types: [opened, synchronize, reopened, labeled]
+  merge_group:
+
+permissions:
+  contents: read
+
+env:
+  # Make sure to exit early if cache segment download times out after 2 minutes.
+  # We limit cache download as a whole to 5 minutes.
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+
+jobs:
+  collector-build:
+    runs-on: ubuntu-24.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+          install-tools: "false"
+      - name: Generate otelcontribcol files
+        run: make genotelcontribcol
+      - name: Build Collector
+        run: make otelcontribcol
+      - name: Upload Collector Binary
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: collector-binary
+          path: ./bin/*
+      - run: ./.github/workflows/scripts/check-disk-space.sh
+
+  supervisor-test:
+    runs-on: ubuntu-24.04
+    needs: collector-build
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+          install-tools: "false"
+      - name: Download Collector Binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: collector-binary
+          path: bin/
+      - run: chmod +x bin/*
+      - name: Run opampsupervisor e2e tests
+        run: |
+          cd cmd/opampsupervisor
+          go test -v --tags=e2e
+      - run: ./.github/workflows/scripts/check-disk-space.sh
+
+  windows-collector-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, windows-11-arm]
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+      - name: Generate otelcontribcol files
+        run: make genotelcontribcol
+      - name: Build Collector
+        run: make otelcontribcol
+      - name: Upload Collector Binary
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: collector-binary-${{ matrix.os == 'windows-11-arm' && 'arm64' || 'amd64' }}
+          path: ./bin/*
+      - run: ./.github/workflows/scripts/check-disk-space.sh
+
+  windows-supervisor-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2025, windows-11-arm]
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
+    env:
+      # The gcc installed on the Windows arm64 runner doesn't ship native ARM libraries so we need to disable CGO.
+      CGO_ENABLED: ${{ matrix.os == 'windows-11-arm' && '0' || '' }}
+    needs: [windows-collector-build]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+      - name: Download Collector Binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: collector-binary-${{ matrix.os == 'windows-11-arm' && 'arm64' || 'amd64' }}
+          path: bin/
+      - name: Run opampsupervisor e2e tests
+        run: |
+          cd cmd/opampsupervisor
+          go test -v --tags=e2e
+      - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/opampsupervisor-image.yml
+++ b/.github/workflows/opampsupervisor-image.yml
@@ -1,0 +1,65 @@
+name: opampsupervisor-image
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+    paths-ignore:
+      - "**/README.md"
+  merge_group:
+  pull_request:
+    paths-ignore:
+      - "**/README.md"
+
+env:
+  IMAGE_NAME: cgx.jfrog.io/coralogix-docker-images/cx-opampsupervisor
+  # Make sure to exit early if cache segment download times out after 2 minutes.
+  # We limit cache download as a whole to 5 minutes.
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+
+# Do not cancel this workflow on main. See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16616
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    env:
+      SHOULD_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+      IMAGE_TAG: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) && github.ref_name || format('local-{0}', github.run_id) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+          install-tools: "false"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Build linux binaries
+        run: |
+          GOOS=linux GOARCH=amd64 make opampsupervisor
+          GOOS=linux GOARCH=arm64 make opampsupervisor
+          cp bin/opampsupervisor_linux_amd64 cmd/opampsupervisor/opampsupervisor-linux-amd64
+          cp bin/opampsupervisor_linux_arm64 cmd/opampsupervisor/opampsupervisor-linux-arm64
+      - name: Login to JFrog
+        if: env.SHOULD_PUSH == 'true'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: cgx.jfrog.io
+          username: ${{ secrets.JFROG_USER }}
+          password: ${{ secrets.JFROG_PASSWORD }}
+      - name: Build and optionally publish image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        with:
+          context: cmd/opampsupervisor
+          file: cmd/opampsupervisor/Dockerfile.release
+          push: ${{ env.SHOULD_PUSH == 'true' }}
+          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          platforms: linux/amd64,linux/arm64
+      - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/opampsupervisor-tests.yml
+++ b/.github/workflows/opampsupervisor-tests.yml
@@ -1,0 +1,132 @@
+name: opampsupervisor-tests
+on:
+  push:
+    branches: [main]
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+  merge_group:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+permissions: read-all
+
+env:
+  TEST_RESULTS: testbed/tests/results/junit/results.xml
+  # Make sure to exit early if cache segment download times out after 2 minutes.
+  # We limit cache download as a whole to 5 minutes.
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+
+# Do not cancel this workflow on main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  setup-environment:
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+      - run: ./.github/workflows/scripts/check-disk-space.sh
+
+  linux-supervisor-tests:
+    runs-on: ubuntu-24.04
+    needs: [setup-environment]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+          install-tools: "false"
+      - name: Run opampsupervisor tests (non-e2e)
+        run: |
+          cd cmd/opampsupervisor
+          go test -v ./...
+      - run: ./.github/workflows/scripts/check-disk-space.sh
+
+  windows-setup-environment:
+    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [windows-latest, windows-11-arm]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+      - run: ./.github/workflows/scripts/check-disk-space.sh
+
+  windows-supervisor-tests:
+    needs: [windows-setup-environment]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2025, windows-11-arm]
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
+    env:
+      # Limit memory usage via GC environment variables to avoid OOM on GH runners, especially for `cmd/otelcontribcol`,
+      # see https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28682#issuecomment-1802296776
+      GOGC: 50
+      GOMEMLIMIT: 2GiB
+      # The gcc installed on the Windows arm64 runner doesn't ship native ARM libraries so we need to disable CGO.
+      CGO_ENABLED: ${{ matrix.os == 'windows-11-arm' && '0' || '' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+      - name: Ensure required ports in the dynamic range are available
+        run: |
+          & ${{ github.workspace }}\.github\workflows\scripts\win-required-ports.ps1
+      - name: Run opampsupervisor tests (non-e2e)
+        run: |
+          cd cmd/opampsupervisor
+          go test -v ./...
+      - run: ./.github/workflows/scripts/check-disk-space.sh
+
+  windows-supervisor-service-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2025, windows-11-arm]
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
+    needs: [windows-setup-environment]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+      - name: Ensure required ports in the dynamic range are available
+        run: |
+          & ${{ github.workspace }}\.github\workflows\scripts\win-required-ports.ps1
+      - name: Generate otelcontribcol files
+        run: make genotelcontribcol
+      - name: Build Collector
+        run: make otelcontribcol
+      - name: Build supervisor
+        run: cd cmd/opampsupervisor; go build
+      - name: Install supervisor as a service
+        run: |
+          New-Service -Name "opampsupervisor" -StartupType "Manual" -BinaryPathName "`"${PWD}\cmd\opampsupervisor`" --config `"${PWD}\cmd\opampsupervisor\supervisor\testdata\supervisor_windows_service_test_config.yaml`""
+          eventcreate.exe /t information /id 1 /l application /d "Creating event provider for 'opampsupervisor'" /so opampsupervisor
+      - name: Test supervisor service
+        working-directory: ${{ github.workspace }}/cmd/opampsupervisor
+        run: |
+          go test -timeout 90s -run ^TestSupervisorAsService$ -v -tags=win32service
+      - name: Remove opampsupervisor service
+        if: always()
+        run: |
+          Remove-Service opampsupervisor
+          Remove-Item HKLM:\SYSTEM\CurrentControlSet\Services\EventLog\Application\opampsupervisor
+      - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/cmd/opampsupervisor/Dockerfile.release
+++ b/cmd/opampsupervisor/Dockerfile.release
@@ -1,0 +1,15 @@
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+RUN apk --update add ca-certificates
+
+ARG SERVICE_NAME=opampsupervisor
+ARG TARGETARCH
+
+RUN addgroup --gid 10001 --system ${SERVICE_NAME} && \
+    adduser --ingroup ${SERVICE_NAME} --shell /bin/false \
+    --disabled-password --uid 10001 ${SERVICE_NAME}
+
+USER ${SERVICE_NAME}
+WORKDIR /home/${SERVICE_NAME}
+
+COPY --chmod=755 opampsupervisor-linux-${TARGETARCH} /usr/local/bin/opampsupervisor
+ENTRYPOINT ["opampsupervisor"]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds some simple CI and release automation for `cmd/opampsupervisor` package in this fork, including a release Dockerfile and three GitHub Actions workflows for running unit tests, e2e tests and the release itself.

The workflows and Dockerfile are based on their upstream counterparts.
