### PR TITLE
[confmap/providers/objstore] Support full objstore config file

### DIFF
--- a/cmd/opampsupervisor/supervisor/config/confmap_helpers_test.go
+++ b/cmd/opampsupervisor/supervisor/config/confmap_helpers_test.go
@@ -33,6 +33,18 @@ func TestRetrieveURIForProvider(t *testing.T) {
 			wantProvider: "file",
 		},
 		{
+			name:         "absolute path is file",
+			uri:          "/etc/otel/configs.prod.yaml",
+			wantURI:      "file:/etc/otel/configs.prod.yaml",
+			wantProvider: "file",
+		},
+		{
+			name:         "relative path is file",
+			uri:          "./config.prod.yaml",
+			wantURI:      "file:./config.prod.yaml",
+			wantProvider: "file",
+		},
+		{
 			name:         "s3 URI keeps s3 scheme",
 			uri:          "s3://bucket.s3.us-east-1.amazonaws.com/config.yaml",
 			wantURI:      "s3://bucket.s3.us-east-1.amazonaws.com/config.yaml",

--- a/confmap/provider/objstoreprovider/provider.go
+++ b/confmap/provider/objstoreprovider/provider.go
@@ -57,15 +57,24 @@ func newProvider(confmap.ProviderSettings) confmap.Provider {
 }
 
 func newObjstoreBucket(providerType string, config []byte) (objectStoreBucket, error) {
-	var providerConfig any
+	var providerConfig client.BucketConfig
 	if err := yaml.Unmarshal(config, &providerConfig); err != nil {
 		return nil, fmt.Errorf("failed to parse objstore config: %w", err)
 	}
 
-	return client.NewBucketFromConfig(log.NewNopLogger(), &client.BucketConfig{
-		Type:   objstore.ObjProvider(providerType),
-		Config: providerConfig,
-	}, componentName, nil)
+	if providerType != "" {
+		if !strings.EqualFold(string(providerConfig.Type), providerType) {
+			return nil, fmt.Errorf("objstore config type %q does not match type %q in URI", providerConfig.Type, providerType)
+		}
+		providerConfig.Type = objstore.ObjProvider(providerType)
+	}
+
+	return client.NewBucketFromConfig(
+		log.NewNopLogger(),
+		&providerConfig,
+		componentName,
+		nil,
+	)
 }
 
 func (p *provider) Retrieve(ctx context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {

--- a/confmap/provider/objstoreprovider/provider_test.go
+++ b/confmap/provider/objstoreprovider/provider_test.go
@@ -43,6 +43,16 @@ func (b *testBucket) Close() error {
 	return nil
 }
 
+func writeFilesystemObjstoreConfig(t *testing.T, bucketDir string) string {
+	configPath := filepath.Join(t.TempDir(), "objstore.yaml")
+	require.NoError(t, os.WriteFile(configPath, fmt.Appendf(nil, `
+type: FILESYSTEM
+config:
+  directory: %q
+`, bucketDir), 0o600))
+	return configPath
+}
+
 func TestRetrieveFromFilesystemBucket(t *testing.T) {
 	bucketDir := t.TempDir()
 	configDir := filepath.Join(bucketDir, "configs")
@@ -59,11 +69,7 @@ service:
       exporters: [nop]
 `), 0o600))
 
-	configPath := filepath.Join(t.TempDir(), "objstore.yaml")
-	require.NoError(t, os.WriteFile(configPath, fmt.Appendf(nil, `
-directory: %q
-`, bucketDir), 0o600))
-	t.Setenv(configPathEnvVar, configPath)
+	t.Setenv(configPathEnvVar, writeFilesystemObjstoreConfig(t, bucketDir))
 
 	fp := NewFactory().Create(confmap.ProviderSettings{})
 	retrieved, err := fp.Retrieve(
@@ -99,11 +105,7 @@ service:
       exporters: [nop]
 `), 0o600))
 
-	configPath := filepath.Join(t.TempDir(), "objstore.yaml")
-	require.NoError(t, os.WriteFile(configPath, fmt.Appendf(nil, `
-directory: %q
-`, bucketDir), 0o600))
-	t.Setenv(configPathEnvVar, configPath)
+	t.Setenv(configPathEnvVar, writeFilesystemObjstoreConfig(t, bucketDir))
 
 	resolver, err := confmap.NewResolver(confmap.ResolverSettings{
 		URIs:              []string{"objstore:configs/otel.yaml?type=filesystem"},
@@ -142,6 +144,25 @@ func TestRetrieveUsesConfigFileAndObjectName(t *testing.T) {
 	raw, err := retrieved.AsRaw()
 	require.NoError(t, err)
 	assert.Contains(t, raw, "receivers")
+}
+
+func TestNewObjstoreBucketValidatesConfigType(t *testing.T) {
+	bucketDir := t.TempDir()
+
+	bucket, err := newObjstoreBucket("filesystem", fmt.Appendf(nil, `
+type: FILESYSTEM
+config:
+  directory: %q
+`, bucketDir))
+	require.NoError(t, err)
+	require.NoError(t, bucket.Close())
+
+	_, err = newObjstoreBucket("s3", fmt.Appendf(nil, `
+type: FILESYSTEM
+config:
+  directory: %q
+`, bucketDir))
+	require.ErrorContains(t, err, `objstore config type "FILESYSTEM" does not match type "s3" in URI`)
 }
 
 func TestRetrieveErrors(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Before we were just using the inner `config` key and not the `prefix` nor `type` (which was always and only inferred via the `type` query parameter).

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes CX-41562.