### PR TITLE
[confmap/providers/objstore] Allow type to come only from query param

### DIFF
--- a/confmap/provider/objstoreprovider/provider.go
+++ b/confmap/provider/objstoreprovider/provider.go
@@ -62,10 +62,13 @@ func newObjstoreBucket(providerType string, config []byte) (objectStoreBucket, e
 		return nil, fmt.Errorf("failed to parse objstore config: %w", err)
 	}
 
-	if providerType != "" {
+	if providerType != "" && providerConfig.Type != "" {
 		if !strings.EqualFold(string(providerConfig.Type), providerType) {
 			return nil, fmt.Errorf("objstore config type %q does not match type %q in URI", providerConfig.Type, providerType)
 		}
+	}
+
+	if providerType != "" {
 		providerConfig.Type = objstore.ObjProvider(providerType)
 	}
 

--- a/confmap/provider/objstoreprovider/provider_test.go
+++ b/confmap/provider/objstoreprovider/provider_test.go
@@ -157,6 +157,13 @@ config:
 	require.NoError(t, err)
 	require.NoError(t, bucket.Close())
 
+	bucket, err = newObjstoreBucket("filesystem", fmt.Appendf(nil, `
+config:
+  directory: %q
+`, bucketDir))
+	require.NoError(t, err)
+	require.NoError(t, bucket.Close())
+
 	_, err = newObjstoreBucket("s3", fmt.Appendf(nil, `
 type: FILESYSTEM
 config:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Allows the type to come from query param when it's empty on the config.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes CX-41562.