### PR TITLE
[confmap/providers/objstore] Allow empty uri on URI

### DIFF
--- a/confmap/provider/objstoreprovider/provider.go
+++ b/confmap/provider/objstoreprovider/provider.go
@@ -137,11 +137,6 @@ func parseURI(uri string) (string, string, error) {
 		return "", "", fmt.Errorf("%q uri is not supported by %q provider", uri, schemeName)
 	}
 
-	providerType := parsed.Query().Get(typeQueryName)
-	if providerType == "" {
-		return "", "", fmt.Errorf("%q uri must include a non-empty %q query parameter", uri, typeQueryName)
-	}
-
 	objectName := objectNameFromURL(parsed)
 	objectName, err = url.PathUnescape(objectName)
 	if err != nil {
@@ -150,7 +145,7 @@ func parseURI(uri string) (string, string, error) {
 	if objectName == "" {
 		return "", "", fmt.Errorf("%q uri must include a non-empty object name", uri)
 	}
-
+	providerType := parsed.Query().Get(typeQueryName)
 	return providerType, objectName, nil
 }
 

--- a/confmap/provider/objstoreprovider/provider_test.go
+++ b/confmap/provider/objstoreprovider/provider_test.go
@@ -170,6 +170,12 @@ config:
   directory: %q
 `, bucketDir))
 	require.ErrorContains(t, err, `objstore config type "FILESYSTEM" does not match type "s3" in URI`)
+
+	_, err = newObjstoreBucket("", fmt.Appendf(nil, `
+config:
+  directory: %q
+`, bucketDir))
+	require.Error(t, err)
 }
 
 func TestRetrieveErrors(t *testing.T) {
@@ -274,6 +280,12 @@ func TestParseURI(t *testing.T) {
 			name:       "escaped object name",
 			uri:        "objstore:" + url.PathEscape("configs/nested otel.yaml") + "?type=filesystem",
 			provider:   "filesystem",
+			objectName: "configs/nested otel.yaml",
+		},
+		{
+			name:       "no type on uri (would fallback to config type)",
+			uri:        "objstore:" + url.PathEscape("configs/nested otel.yaml"),
+			provider:   "",
 			objectName: "configs/nested otel.yaml",
 		},
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

It ends up relying on the type from the config, if there is any. If there isn't one there, it culminates in raising an error in the config parser.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes CX-41562.
