### PR TITLE
[cmd/opampsupervisor] Validate initial fallback configuration with agent args

### DIFF
--- a/.github/workflows/opampsupervisor-build-and-test.yml
+++ b/.github/workflows/opampsupervisor-build-and-test.yml
@@ -1,0 +1,52 @@
+name: opampsupervisor-build-and-test
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**/README.md"
+  merge_group:
+  pull_request:
+    paths-ignore:
+      - "**/README.md"
+
+permissions:
+  contents: read
+
+env:
+  # Make sure to exit early if cache segment download times out after 2 minutes.
+  # We limit cache download as a whole to 5 minutes.
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+
+# Do not cancel this workflow on main. See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16616
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+      - name: Run opampsupervisor unit tests
+        working-directory: cmd/opampsupervisor
+        run: make test
+      - run: ./.github/workflows/scripts/check-disk-space.sh
+
+  e2e-tests:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+      - name: Run opampsupervisor e2e tests
+        working-directory: cmd/opampsupervisor
+        run: make e2e-test
+      - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -389,7 +389,7 @@ func escapePathStringForWin(path string) string {
 }
 
 // This test ensures the Supervisor config validation path can validate
-// agent::startup_fallback_configs by executing the real Collector binary with:
+// agent::initial_fallback_configs by executing the real Collector binary with:
 //
 //	<collector> validate --config <cfg1> [--config <cfg2> ...]
 //
@@ -411,11 +411,27 @@ func TestValidateFallbackConfigsWithColBin_E2E(t *testing.T) {
 		cfgFile := getSupervisorConfig(t, "fallback", map[string]string{
 			"url":                     "localhost:12345",
 			"storage_dir":             t.TempDir(),
-			"startup_fallback_config": escapePathStringForWin(goodColConfigPath),
+			"initial_fallback_config": escapePathStringForWin(goodColConfigPath),
 		})
 
 		cfg, err := config.Load(cfgFile.Name())
 		require.NoError(t, err)
+		_, err = supervisor.NewSupervisor(t.Context(), zap.NewNop(), cfg)
+		require.NoError(t, err)
+	})
+
+	t.Run("Valid profiles fallback config using agent feature gates", func(t *testing.T) {
+		profilesConfigPath := filepath.Join("testdata", "collector", "profiles_pipeline.yaml")
+		cfgFile := getSupervisorConfig(t, "fallback", map[string]string{
+			"url":                     "localhost:12345",
+			"storage_dir":             t.TempDir(),
+			"agent_argument":          "--feature-gates=+service.profilesSupport",
+			"initial_fallback_config": escapePathStringForWin(profilesConfigPath),
+		})
+
+		cfg, err := config.Load(cfgFile.Name())
+		require.NoError(t, err)
+		require.Equal(t, []string{"--feature-gates=+service.profilesSupport"}, cfg.Agent.Arguments)
 		_, err = supervisor.NewSupervisor(t.Context(), zap.NewNop(), cfg)
 		require.NoError(t, err)
 	})
@@ -425,13 +441,13 @@ func TestValidateFallbackConfigsWithColBin_E2E(t *testing.T) {
 		badCfgFile := getSupervisorConfig(t, "fallback", map[string]string{
 			"url":                     "localhost:12345",
 			"storage_dir":             t.TempDir(),
-			"startup_fallback_config": escapePathStringForWin(badColConfigPath),
+			"initial_fallback_config": escapePathStringForWin(badColConfigPath),
 		})
 
 		cfg, err := config.Load(badCfgFile.Name())
 		require.NoError(t, err)
 		_, err = supervisor.NewSupervisor(t.Context(), zap.NewNop(), cfg)
-		require.ErrorContains(t, err, "could not validate startup fallback configs with agent::executable")
+		require.ErrorContains(t, err, "could not validate initial fallback configs with agent::executable")
 	})
 }
 

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -3609,8 +3609,8 @@ func enableExtensionsFeatureGate(t *testing.T) {
 }
 
 // supervisorBinarySizeLimitBytes is the size budget for the supervisor binary,
-// in bytes. 24 MiB.
-const supervisorBinarySizeLimitBytes = 24 * 1024 * 1024
+// in bytes. This fork includes S3 and objstore providers, which link cloud SDKs.
+const supervisorBinarySizeLimitBytes = 64 * 1024 * 1024
 
 // TestSupervisorBinarySize guards against unintended growth of the supervisor
 // binary. It builds the supervisor with the same flags used for release

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -826,7 +826,7 @@ func TestSupervisorStartsCollectorWithNoOpAMPServerUsingLastRemoteConfig(t *test
 			extraConfigData := map[string]string{
 				"url":                     server.addr,
 				"storage_dir":             storageDir,
-				"startup_fallback_config": escapePathStringForWin(fallbackConfigPath),
+				"initial_fallback_config": escapePathStringForWin(fallbackConfigPath),
 			}
 			if mode.UseHUPConfigReload {
 				extraConfigData["use_hup_config_reload"] = "true"
@@ -3096,7 +3096,7 @@ func TestSupervisorFallbackWhenNoPersistedConfig(t *testing.T) {
 		"url":                     server.addr,
 		"storage_dir":             storageDir,
 		"local_config":            localConfigPath,
-		"startup_fallback_config": escapePathStringForWin(fallbackConfigPath),
+		"initial_fallback_config": escapePathStringForWin(fallbackConfigPath),
 	})
 
 	require.NoError(t, s.Start(t.Context()))
@@ -3161,7 +3161,7 @@ func TestSupervisorFallbackDisablesAfterFirstConnect(t *testing.T) {
 		"url":                     server.addr,
 		"storage_dir":             storageDir,
 		"local_config":            localConfigPath,
-		"startup_fallback_config": escapePathStringForWin(fallbackConfigPath),
+		"initial_fallback_config": escapePathStringForWin(fallbackConfigPath),
 	})
 
 	require.NoError(t, s.Start(t.Context()))

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -332,6 +332,8 @@ func (a Agent) validateFallbackConfigsWithColBin() error {
 	}
 
 	cfgValidateCommand := []string{a.Executable, "validate", "--config", tmpCfgPath}
+	cfgValidateCommand = append(cfgValidateCommand, a.Arguments...)
+
 	cmd := exec.Command(cfgValidateCommand[0], cfgValidateCommand[1:]...) // #nosec G204
 
 	cmd.Stdout = os.Stdout

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -870,7 +870,16 @@ func writeValidateStub(t *testing.T, requiredSubstring, forbiddenSubstring strin
 			"if errorlevel 1 exit /b 1",
 		}
 		if len(requiredArg) > 0 {
-			script = append(script, "if not \"%4\"==\""+requiredArg[0]+"\" exit /b 1")
+			// cmd.exe uses "=" as a delimiter when assigning batch parameters.
+			name, value, hasValue := strings.Cut(requiredArg[0], "=")
+			if hasValue {
+				script = append(script,
+					"if not \"%4\"==\""+name+"\" exit /b 1",
+					"if not \"%5\"==\""+value+"\" exit /b 1",
+				)
+			} else {
+				script = append(script, "if not \"%4\"==\""+name+"\" exit /b 1")
+			}
 		}
 		if forbiddenSubstring != "" {
 			script = append(script,

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -791,6 +791,19 @@ func TestOpAMPServer_OpaqueHeaders(t *testing.T) {
 }
 
 func TestAgent_validateFallbackConfigsWithColBin(t *testing.T) {
+	t.Run("validates a profiles pipeline using feature gates from agent arguments", func(t *testing.T) {
+		validateStub := writeValidateStub(t, "profiles:", "processors:", "--feature-gates=+service.profilesSupport")
+		fallbackPath := filepath.Join("..", "..", "testdata", "collector", "profiles_pipeline.yaml")
+
+		agent := Agent{
+			Executable:             validateStub,
+			Arguments:              []string{"--feature-gates=+service.profilesSupport"},
+			InitialFallbackConfigs: []string{fallbackPath},
+		}
+
+		require.NoError(t, agent.validateFallbackConfigsWithColBin())
+	})
+
 	t.Run("uses the first readable fallback config", func(t *testing.T) {
 		validateStub := writeValidateStub(t, "nop:", "logging:")
 		firstPath := writeFallbackConfig(t, "first.yaml", "exporters:\n  nop:\n")
@@ -844,7 +857,7 @@ func writeFallbackConfig(t *testing.T, fileName, contents string) string {
 	return path
 }
 
-func writeValidateStub(t *testing.T, requiredSubstring, forbiddenSubstring string) string {
+func writeValidateStub(t *testing.T, requiredSubstring, forbiddenSubstring string, requiredArg ...string) string {
 	t.Helper()
 
 	tempDir := t.TempDir()
@@ -855,6 +868,9 @@ func writeValidateStub(t *testing.T, requiredSubstring, forbiddenSubstring strin
 			"set CFG=%3",
 			"findstr /C:\"" + requiredSubstring + "\" \"%CFG%\" >nul",
 			"if errorlevel 1 exit /b 1",
+		}
+		if len(requiredArg) > 0 {
+			script = append(script, "if not \"%4\"==\""+requiredArg[0]+"\" exit /b 1")
 		}
 		if forbiddenSubstring != "" {
 			script = append(script,
@@ -872,6 +888,9 @@ func writeValidateStub(t *testing.T, requiredSubstring, forbiddenSubstring strin
 		"#!/bin/sh",
 		"cfg=\"$3\"",
 		"grep -q '" + requiredSubstring + "' \"$cfg\" || exit 1",
+	}
+	if len(requiredArg) > 0 {
+		script = append(script, "[ \"$4\" = '"+requiredArg[0]+"' ] || exit 1")
 	}
 	if forbiddenSubstring != "" {
 		script = append(script, "grep -q '"+forbiddenSubstring+"' \"$cfg\" && exit 1")

--- a/cmd/opampsupervisor/testdata/collector/profiles_pipeline.yaml
+++ b/cmd/opampsupervisor/testdata/collector/profiles_pipeline.yaml
@@ -1,0 +1,14 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:0
+
+exporters:
+  debug:
+
+service:
+  pipelines:
+    profiles:
+      receivers: [otlp]
+      exporters: [debug]

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_fallback.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_fallback.yaml
@@ -16,6 +16,10 @@ storage:
 
 agent:
   executable: ../../bin/otelcontribcol_{{.goos}}_{{.goarch}}{{.extension}}
+  {{- if .agent_argument }}
+  args:
+    - '{{.agent_argument}}'
+  {{- end }}
   {{- if .local_config }}
   config_files:
     - '{{.local_config}}'
@@ -25,4 +29,3 @@ agent:
   {{- if .use_hup_config_reload }}
   use_hup_config_reload: {{ .use_hup_config_reload }}
   {{- end }}
-


### PR DESCRIPTION
#### Description

Fixes CX-49277.

This makes the initial fallback configuration validation use the agent's args. This ensures features gates are correctly used to validate configurations that might depend on them.